### PR TITLE
Replace Void by Nil in return types

### DIFF
--- a/spec/dexter_spec.cr
+++ b/spec/dexter_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 private struct RawFormatter < Dexter::Formatters::BaseLogFormatter
-  def format(data)
+  def format(data) : Nil
     io << data
   end
 end

--- a/src/dexter/formatters/base_log_formatter.cr
+++ b/src/dexter/formatters/base_log_formatter.cr
@@ -11,7 +11,7 @@ module Dexter
       )
       end
 
-      abstract def format(data : NamedTuple) : Void
+      abstract def format(data : NamedTuple) : Nil
     end
   end
 end

--- a/src/dexter/formatters/json_log_formatter.cr
+++ b/src/dexter/formatters/json_log_formatter.cr
@@ -4,7 +4,7 @@ require "./base_log_formatter"
 module Dexter
   module Formatters
     struct JsonLogFormatter < BaseLogFormatter
-      def format(data) : Void
+      def format(data) : Nil
         {severity: severity.to_s, timestamp: timestamp}.merge(data).to_json(io)
       end
     end

--- a/src/dexter/logger.cr
+++ b/src/dexter/logger.cr
@@ -25,7 +25,7 @@ module Dexter
 
     {% for name in ::Logger::Severity.constants %}
     # Logs *message* if the logger's current severity is lower or equal to `{{name.id}}`.
-    def {{name.id.downcase}}(data : NamedTuple) : Void
+    def {{name.id.downcase}}(data : NamedTuple) : Nil
       log(Severity::{{name.id}}, data)
     end
 
@@ -34,28 +34,28 @@ module Dexter
     # Same as `{{ name.id }} but does not require surrounding data with {}:
     #
     # Example: `Dexter::Logger.new(STDOUT).{{ name.id }}(data: "my_data")`
-    def {{name.id.downcase}}(**data) : Void
+    def {{name.id.downcase}}(**data) : Nil
       log(Severity::{{name.id}}, data)
     end
   {% end %}
 
-    def log(severity : ::Logger::Severity, **data) : Void
+    def log(severity : ::Logger::Severity, **data) : Nil
       log(severity: severity, data: data)
     end
 
-    def log(severity : ::Logger::Severity, data : NamedTuple) : Void
+    def log(severity : ::Logger::Severity, data : NamedTuple) : Nil
       return if severity < level || !@io
       write(severity, Time.now, @progname, data)
     end
 
     # :nodoc:
-    def formatter=(value) : Void
+    def formatter=(value) : Nil
       puts <<-TEXT
       Dexter::Logger ignores 'formatter=' because it uses its own formatter. Please use 'log_formatter=' instead.
       TEXT
     end
 
-    private def write(severity : ::Logger::Severity, datetime : Time, progname, message : String | NamedTuple) : Void
+    private def write(severity : ::Logger::Severity, datetime : Time, progname, message : String | NamedTuple) : Nil
       io = @io
       return unless io
 


### PR DESCRIPTION
`Void` is expected to be used in C lib interop functions, to keep something more idiomatic, but they are effectively a `Nil`.

In Crystal code `Nil` should be used. I found this while upgrading for Crystal 0.30.0, and to enforce the return type in subclasses of `BaseLogFormatter` I figure it would be better to change it here first.