### PR TITLE
Update to Crystal 0.33.0

### DIFF
--- a/src/dexter/logger.cr
+++ b/src/dexter/logger.cr
@@ -45,7 +45,7 @@ module Dexter
 
     def log(severity : ::Logger::Severity, data : NamedTuple) : Nil
       return if severity < level || !@io
-      write(severity, Time.now, @progname, data)
+      write(severity, Time.utc, @progname, data)
     end
 
     # :nodoc:


### PR DESCRIPTION
`Time.now` was deprecated in 0.28.0 and will be removed in 0.33.0.

I am not sure whether utc or local is prefered in this case