### PR TITLE
Cleanup some specs

### DIFF
--- a/spec/dexter_spec.cr
+++ b/spec/dexter_spec.cr
@@ -11,14 +11,15 @@ describe Dexter::Logger do
     build_logger.should be_a(::Logger)
   end
 
-  it "converts string into NamedTuple" do
+  it "ignores the base logger formatter=, but still returns the logging" do
     io = IO::Memory.new
     logger = build_logger(io)
     logger.formatter = "Whatever"
 
     logger.info("Something")
 
-    io.to_s.chomp.should eq(%({message: "Something"}))
+    io.to_s.chomp.should contain(%(Please use 'log_formatter=' instead))
+    io.to_s.chomp.should contain(%({message: "Something"}))
   end
 
   it "converts string into NamedTuple" do

--- a/src/dexter/logger.cr
+++ b/src/dexter/logger.cr
@@ -50,7 +50,7 @@ module Dexter
 
     # :nodoc:
     def formatter=(value) : Nil
-      puts <<-TEXT
+      (@io || STDOUT).puts <<-TEXT
       Dexter::Logger ignores 'formatter=' because it uses its own formatter. Please use 'log_formatter=' instead.
       TEXT
     end


### PR DESCRIPTION
We had a duplicate spec, but one was using the formatter setter which we ignore. This makes the spec a little more important by testing that we let the user know about this. 

It still prints out your log info as normal, it just also adds in that message.