### PR TITLE
Revamp 0.2.0

### DIFF
--- a/spec/json_log_formatter_spec.cr
+++ b/spec/json_log_formatter_spec.cr
@@ -24,6 +24,17 @@ describe Dexter::JSONLogFormatter do
     log["other"].as_h.should eq({"arr" => [1]})
   end
 
+  it "prints local context data first" do
+    io = IO::Memory.new
+    entry = build_entry({global: true, local: {foo: "bar"}}, source: "json-test", severity: :debug)
+
+    format(entry, io)
+
+    io.to_s.chomp.should eq(
+      {severity: "Debug", source: "json-test", timestamp: timestamp, foo: "bar", global: true}.to_json
+    )
+  end
+
   it "merge the message if present" do
     io = IO::Memory.new
     entry = build_entry({my_data: "is great!"}, message: "my message")

--- a/spec/log_spec.cr
+++ b/spec/log_spec.cr
@@ -2,12 +2,12 @@ require "./spec_helper"
 
 describe Log do
   {% for name, _severity in ::Log::SEVERITY_MAP %}
-    it "logs NamedTuple data for '{{ name.id.downcase }}'" do
+    it "logs NamedTuple data for '{{ name.id.downcase }}' to message data" do
       entry = log_stubbed do |log|
         log.{{ name.id.downcase }} { {foo: "bar" }}
       end
 
-      entry.context.as_h.transform_values(&.as_s).should eq({"foo" => "bar"})
+      entry.message_data.as_h.transform_values(&.as_s).should eq({"foo" => "bar"})
       entry.message.should eq("")
     end
   {% end %}

--- a/src/dexter/json_log_formatter.cr
+++ b/src/dexter/json_log_formatter.cr
@@ -3,7 +3,15 @@ require "json"
 module Dexter
   struct JSONLogFormatter < BaseFormatter
     def call
-      data = default_data.merge(entry.context.as_h)
+      context_data = entry.context.as_h
+      local_data = context_data.delete("local").try(&.as_h)
+      data = default_data
+
+      if local_data
+        data = data.merge(local_data)
+      end
+
+      data = data.merge(context_data)
 
       exception_data.try do |exception_data_|
         data = data.merge(exception_data_)
@@ -11,17 +19,17 @@ module Dexter
 
       data
         .compact
-        .reject { |_k, v| v.nil? || v.to_s.try(&.empty?) }
         .to_json(io)
     end
 
     private def default_data
-      {
+      data = {
         "severity"  => entry.severity.to_s,
         "source"    => entry.source,
         "timestamp" => entry.timestamp,
-        "message"   => entry.message,
       }
+      data["message"] = entry.message unless entry.message.empty?
+      data
     end
 
     private def exception_data

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -25,7 +25,7 @@ class Log
     # ```crystal
     # Log.{{ method.id }}(exception) ->{ { query: "SELECT *" } }
     # ```
-    def {{method.id}}(*, exception : Exception? = nil, proc : Proc(Nil, T)) forall T
+    def {{method.id}}(exception : Exception?, proc : Proc)
       return unless backend = @backend
       severity = Severity.new({{severity}})
       return unless level <= severity
@@ -36,6 +36,10 @@ class Log
         Log.context.set(local: proc_result)
         {{method.id}}(exception: exception) { "" }
       end
+    end
+
+    def {{method.id}}(proc : Proc)
+      {{ method.id }}(exception: nil, proc: proc)
     end
   {% end %}
 end

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -38,6 +38,7 @@ class Log
       end
     end
 
+    # :nodoc:
     def {{method.id}}(proc : Proc)
       {{ method.id }}(exception: nil, proc: proc)
     end


### PR DESCRIPTION
* Use a new overload instead of monkey patching existing method
* Keep log context and entry largely the same
* Store log data under a `local` key in the context so it can be handled differently by Dexter formatters

This is all 100% compatible with Crystal `Log` so Dexter will work with other loggers and formatters just fine