### PR TITLE
Use dexter namespace

### DIFF
--- a/spec/log_spec.cr
+++ b/spec/log_spec.cr
@@ -1,10 +1,10 @@
 require "./spec_helper"
 
 describe Log do
-  {% for name, _severity in ::Log::SEVERITY_MAP %}
+  {% for name, _severity in Log::Dexter::SEVERITY_MAP %}
     it "logs NamedTuple data for '{{ name.id.downcase }}' to 'local' context" do
       entry = log_stubbed do |log|
-        log.{{ name.id.downcase }} ->{ {foo: "bar" }}
+        log.dexter.{{ name.id.downcase }} { {foo: "bar" }}
       end
 
       entry.context["local"].as_h.transform_values(&.as_s).should eq({"foo" => "bar"})
@@ -13,7 +13,7 @@ describe Log do
 
     it "logs Hash data for '{{ name.id.downcase }}' to 'local' context" do
       entry = log_stubbed do |log|
-        log.{{ name.id.downcase }} ->{ {"foo" => "bar" }}
+        log.dexter.{{ name.id.downcase }} { {"foo" => "bar" }}
       end
 
       entry.context["local"].as_h.transform_values(&.as_s).should eq({"foo" => "bar"})
@@ -23,7 +23,7 @@ describe Log do
 
   it "allows logging data with nil values" do
     entry = log_stubbed do |log|
-      log.info ->{ {"foo" => nil} }
+      log.dexter.info { {"foo" => nil} }
     end
 
     entry.context["local"]["foo"].should eq("")
@@ -33,7 +33,7 @@ describe Log do
   it "allows passing an exception" do
     ex = RuntimeError.new
     entry = log_stubbed do |log|
-      log.info ex, ->{ {"foo" => nil} }
+      log.dexter.info(exception: ex) { {"foo" => nil} }
     end
 
     entry.exception.should eq(ex)

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -4,43 +4,49 @@ require "./base_formatter"
 require "./json_log_formatter"
 
 class Log
-  SEVERITY_MAP = {
-    debug:   Severity::Debug,
-    verbose: Severity::Verbose,
-    info:    Severity::Info,
-    warn:    Severity::Warning,
-    error:   Severity::Error,
-    fatal:   Severity::Fatal,
-  }
+  def dexter : Dexter
+    Dexter.new(self)
+  end
 
-  {% for method, severity in SEVERITY_MAP %}
-    # Logs key/value data in the Log::Context under the 'local' leu
-    #
-    # ```crystal
-    # Log.{{ method.id }} ->{ {path: "/comments", status: 200 }}
-    # ```
-    #
-    # You can also pass an exception:
-    #
-    # ```crystal
-    # Log.{{ method.id }}(exception) ->{ { query: "SELECT *" } }
-    # ```
-    def {{method.id}}(exception : Exception?, proc : Proc)
-      return unless backend = @backend
-      severity = Severity.new({{severity}})
-      return unless level <= severity
+  struct Dexter
+    SEVERITY_MAP = {
+      debug:   Severity::Debug,
+      verbose: Severity::Verbose,
+      info:    Severity::Info,
+      warn:    Severity::Warning,
+      error:   Severity::Error,
+      fatal:   Severity::Fatal,
+    }
 
-      proc_result = proc.call
+    getter log
 
-      Log.with_context do
-        Log.context.set(local: proc_result)
-        {{method.id}}(exception: exception) { "" }
+    def initialize(@log : ::Log)
+    end
+
+    {% for method, severity in SEVERITY_MAP %}
+      # Logs key/value data in the Log::Context under the 'local' leu
+      #
+      # ```crystal
+      # Log.dexter.{{ method.id }} ->{ {path: "/comments", status: 200 }}
+      # ```
+      #
+      # You can also pass an exception:
+      #
+      # ```crystal
+      # Log.dexter.{{ method.id }}(exception) ->{ { query: "SELECT *" } }
+      # ```
+      def {{method.id}}(*, exception : Exception? = nil)
+        return unless backend = log.backend
+        severity = Severity.new({{severity}})
+        return unless log.level <= severity
+
+        block_result = yield
+
+        Log.with_context do
+          Log.context.set(local: block_result)
+          log.{{method.id}}(exception: exception) { "" }
+        end
       end
-    end
-
-    # :nodoc:
-    def {{method.id}}(proc : Proc)
-      {{ method.id }}(exception: nil, proc: proc)
-    end
-  {% end %}
+    {% end %}
+  end
 end

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -35,7 +35,7 @@ class Log
       # ```crystal
       # Log.dexter.{{ method.id }}(exception) ->{ { query: "SELECT *" } }
       # ```
-      def {{method.id}}(*, exception : Exception? = nil)
+      def {{method.id}}(*, exception : Exception? = nil, &block : -> NamedTuple | Hash)
         return unless backend = log.backend
         severity = Severity.new({{severity}})
         return unless log.level <= severity


### PR DESCRIPTION
Just use a block because it's way easier, but namespace in `Log.dexter`. Still easy to use, clear it is in dexter, and we can do whatever we want in there 🎉 