### PR TITLE
Upgrade to Crystal 0.35.0

### DIFF
--- a/spec/json_log_formatter_spec.cr
+++ b/spec/json_log_formatter_spec.cr
@@ -76,7 +76,7 @@ describe Dexter::JSONLogFormatter do
 end
 
 private def format(entry : Log::Entry, io : IO)
-  Dexter::JSONLogFormatter.proc.call(entry, io)
+  Dexter::JSONLogFormatter.proc.format(entry, io)
 end
 
 private def build_entry(context, message = "", source = "", severity : Log::Severity = Log::Severity::Info, data : Log::Metadata = Log::Metadata.empty, exception : Exception? = nil)

--- a/spec/json_log_formatter_spec.cr
+++ b/spec/json_log_formatter_spec.cr
@@ -79,13 +79,14 @@ private def format(entry : Log::Entry, io : IO)
   Dexter::JSONLogFormatter.proc.call(entry, io)
 end
 
-private def build_entry(context, message = "", source = "", severity : Log::Severity = Log::Severity::Info, exception : Exception? = nil)
+private def build_entry(context, message = "", source = "", severity : Log::Severity = Log::Severity::Info, data : Log::Metadata = Log::Metadata.empty, exception : Exception? = nil)
   Log.with_context do
     Log.context.set context
     entry = Log::Entry.new \
       source: source,
       message: message,
       severity: severity,
+      data: data,
       exception: exception
     entry.timestamp = timestamp
     entry

--- a/src/dexter/base_formatter.cr
+++ b/src/dexter/base_formatter.cr
@@ -3,9 +3,9 @@ module Dexter
     getter entry, io
 
     def self.proc
-      ->(entry : Log::Entry, io : IO) {
+      ::Log::Formatter.new do |entry, io|
         new(entry, io).call
-      }
+      end
     end
 
     def initialize(@entry : Log::Entry, @io : IO)

--- a/src/dexter/json_log_formatter.cr
+++ b/src/dexter/json_log_formatter.cr
@@ -6,7 +6,11 @@ require "log/json"
 module Dexter
   struct JSONLogFormatter < BaseFormatter
     def call
-      context_data = entry.context.as_h
+      context_data = Hash(String, ::Log::Metadata::Value).new
+      entry.context.each do |key, value|
+        context_data[key.to_s] = value
+      end
+
       local_data = context_data.delete("local").try(&.as_h)
       data = default_data
 

--- a/src/dexter/json_log_formatter.cr
+++ b/src/dexter/json_log_formatter.cr
@@ -1,4 +1,7 @@
+class Log; end
+
 require "json"
+require "log/json"
 
 module Dexter
   struct JSONLogFormatter < BaseFormatter

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -17,7 +17,7 @@ class Log
       debug:   Severity::Debug,
       verbose: Severity::Verbose,
       info:    Severity::Info,
-      warn:    Severity::Warning,
+      warn:    Severity::Warn,
       error:   Severity::Error,
       fatal:   Severity::Fatal,
     }

--- a/src/dexter/log/context.cr
+++ b/src/dexter/log/context.cr
@@ -1,11 +1,14 @@
-class Log::Context
-  def to_json(builder : JSON::Builder) : Nil
-    @raw.to_json builder
-  end
+{% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+{% else %}
+  class Log::Context
+    def to_json(builder : JSON::Builder) : Nil
+      @raw.to_json builder
+    end
 
-  # TODO: Remove this once https://github.com/crystal-lang/crystal/pull/9104 is merged
-  # and released
-  def initialize(raw : Nil)
-    @raw = ""
+    # TODO: Remove this once https://github.com/crystal-lang/crystal/pull/9104 is merged
+    # and released
+    def initialize(raw : Nil)
+      @raw = ""
+    end
   end
-end
+{% end %}


### PR DESCRIPTION
These are some of the changes I've notice to upgrade to Crystal 0.35.

Probably the local data of log entries can be redesigned to avoid intermediate structures. For now I was focused on make the spec pass.

Feel free to close the PR and use it as input for a cleaner migration.

If only crystal 0.35.0 is wanted, the `compare_versions(Crystal::VERSION, "0.35.0-0")` can be dropped and the crystal property in shard.yml should be updated.