### PR TITLE
Require log in Dexter

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,4 @@
 require "spec"
-require "log"
 require "../src/dexter"
 
 struct Log::Entry

--- a/src/dexter.cr
+++ b/src/dexter.cr
@@ -1,3 +1,4 @@
+require "log"
 require "./dexter/*"
 
 module Dexter


### PR DESCRIPTION
This will avoid potential "Log is not a class, it is a module" errors