### PR TITLE
Ensure sync dispatcher for temporal IOBackend

### DIFF
--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -140,12 +140,17 @@ class Log
     #
     # You can use any combination of `io`, `level`, `formatter`. All are optional.
     def temp_config(io : IO = IO::Memory.new, level : ::Log::Severity = Log::Severity::Debug, formatter : ::Log::Formatter? = nil) : Nil
+      # TODO Log.capture from "log/spec" module
+
       io ||= IO::Memory.new
       log_class = ::Log.for(log.source)
       original_backend = log_class.backend
       original_level = log_class.level
       begin
         backend = Log::IOBackend.new(io)
+        {% if compare_versions(Crystal::VERSION, "1.0.0-0") >= 0 %}
+          backend.dispatcher = Log::Dispatcher.for(:sync)
+        {% end %}
         if formatter
           backend.formatter = formatter
         end


### PR DESCRIPTION
In 1.0.0 with the introduction of `Log::Dispatcher` in https://github.com/crystal-lang/crystal/pull/9432 the entries sent to an `IOBackend` are sent in a separate fiber. This cause some issues in the existing specs when running against master.

Ideally I would suggest to use a MemoryBackend which has a sync dispatcher by default or use Log.capture which provides a DSL for assert log messages (and uses a MemoryBacked).

This PR is the minimum change to keep the sync dispatcher on specs.

