### PR TITLE
Switch to GitHub Actions for specs and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: "*"
+
+jobs:
+  check_format:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:0.35.0
+    steps:
+      - uses: actions/checkout@v1
+      - name: Format
+        run: crystal tool format --check
+  specs:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal:0.35.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install shards
+        run: shards install
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-crystal
+      - name: Create .env file
+        run: touch .env
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    container:
+      image: crystallang/crystal
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: "Install shards"
+        run: shards install
+      - name: "Generate docs"
+        run: crystal docs
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dexter
 
+[![API Documentation Website](https://img.shields.io/website?down_color=red&down_message=Offline&label=API%20Documentation&up_message=Online&url=https%3A%2F%2Fluckyframework.github.io%2Fdexter%2F)](https://luckyframework.github.io/dexter)
+
 Extensions to Crystal's `Log` class.
 
 * 100% compatible with built-in Crystal's [`Log`](https://crystal-lang.org/api/latest/Log.html)


### PR DESCRIPTION
This is part of a series of PRs to get all of our Lucky repositories auto-deploying API documentation to GitHub pages. Having these accessible will assist with the new "Learn" section on the website.

While this does not necessarily supersede #28 since it does matrix testing against multiple Crystal versions, this is a good starting point and gets the basic tests switched over.

This PR contains four main elements:
- Switch from Travis to GitHub Actions
- Add the GitHub Action to build documentation into the `gh-pages` branch
- Add the GitHub Action to run `crystal format` and `crystal spec`
- Add a badge to the README linking to the API documentation