### PR TITLE
Log entry metadata when it's not empty

### DIFF
--- a/spec/json_log_formatter_spec.cr
+++ b/spec/json_log_formatter_spec.cr
@@ -17,7 +17,7 @@ describe Dexter::JSONLogFormatter do
     entry = build_entry({my_data: "is great!"}, source: "json-test", severity: :debug, data: Log::Metadata.build({metadata: "is great!", more_data: "more!"}))
     format(entry, io)
     io.to_s.chomp.should eq(
-      {severity: "Debug", source: "json-test", timestamp: timestamp, data: {metadata: "is great!", more_data: "more!"}.to_json, my_data: "is great!"}.to_json
+      {severity: "Debug", source: "json-test", timestamp: timestamp, data: {metadata: "is great!", more_data: "more!"}, my_data: "is great!"}.to_json
     )
   end
 

--- a/spec/json_log_formatter_spec.cr
+++ b/spec/json_log_formatter_spec.cr
@@ -12,6 +12,15 @@ describe Dexter::JSONLogFormatter do
     )
   end
 
+  it "formats the entry metadata as json" do
+    io = IO::Memory.new
+    entry = build_entry({my_data: "is great!"}, source: "json-test", severity: :debug, data: Log::Metadata.build({metadata: "is great!", more_data: "more!"}))
+    format(entry, io)
+    io.to_s.chomp.should eq(
+      {severity: "Debug", source: "json-test", timestamp: timestamp, data: {metadata: "is great!", more_data: "more!"}.to_json, my_data: "is great!"}.to_json
+    )
+  end
+
   it "formats complex types" do
     io = IO::Memory.new
     entry = build_entry({args: [1], params: {foo: "bar"}, other: {arr: [1]}}, source: "json-test", severity: :debug)

--- a/src/dexter/json_log_formatter.cr
+++ b/src/dexter/json_log_formatter.cr
@@ -24,14 +24,21 @@ module Dexter
     end
 
     private def default_data
-      data = {
-        "severity"  => entry.severity.to_s,
-        "source"    => entry.source,
-        "timestamp" => entry.timestamp,
-      }
-      data["data"] = entry.data.to_json unless entry.data.empty?
+      data = Hash(String, String | Time | Hash(String, String)).new
+      data["severity"] = entry.severity.to_s
+      data["source"] = entry.source
+      data["timestamp"] = entry.timestamp
+      data["data"] = metadata unless entry.data.empty?
       data["message"] = entry.message unless entry.message.empty?
       data
+    end
+
+    private def metadata
+      Hash(String, String).new.tap do |hash|
+        entry.data.each do |key, value|
+          hash[key.to_s] = value.to_s
+        end
+      end
     end
 
     private def exception_data

--- a/src/dexter/json_log_formatter.cr
+++ b/src/dexter/json_log_formatter.cr
@@ -29,6 +29,7 @@ module Dexter
         "source"    => entry.source,
         "timestamp" => entry.timestamp,
       }
+      data["data"] = entry.data.to_json unless entry.data.empty?
       data["message"] = entry.message unless entry.message.empty?
       data
     end


### PR DESCRIPTION
Add log entry metadata as json string to default data.

Some shards log via setting metadata:
```
Log.info &.emit(data: "data")
```

Found this issue while adding ORM Jennifer to Lucky.