### PR TITLE
Lock Crystal to 1.4 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Dexter CI
 
 on:
   push:
@@ -10,16 +10,13 @@ jobs:
   check_format:
     strategy:
       fail-fast: false
-      matrix:
-        crystal_version:
-          - 1.3.2
-        experimental:
-          - false
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    continue-on-error: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: 1.4.1
       - name: Install shards
         run: shards install
       - name: Format
@@ -31,15 +28,17 @@ jobs:
       fail-fast: false
       matrix:
         crystal_version:
-          - 1.0.0
-          - 1.3.2
+          - 1.4.0
+          - latest
         experimental:
           - false
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     steps:
       - uses: actions/checkout@v2
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{matrix.crystal_version}}
       - name: Install shards
         run: shards install
       - name: Cache Crystal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,17 +2,18 @@ name: Deploy docs
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal:1.3.2
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: latest
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"

--- a/shard.yml
+++ b/shard.yml
@@ -4,11 +4,11 @@ version: 0.3.4
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
 
-crystal: ">= 1.0.0"
+crystal: ">= 1.4.0"
 
 license: MIT
 
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.2
+    version: ~> 1.0.0

--- a/spec/log_spec.cr
+++ b/spec/log_spec.cr
@@ -62,9 +62,7 @@ describe Log do
       formatter = ::Log::Formatter.new { |_entry, io| io << "original formatter" }
       backend = ::Log::IOBackend.new(original_io)
       backend.formatter = formatter
-      {% if compare_versions(Crystal::VERSION, "0.36.0-0") >= 0 %}
-        backend.dispatcher = Log::Dispatcher.for(:sync)
-      {% end %}
+      backend.dispatcher = Log::Dispatcher.for(:sync)
       log = Log.for("temp_config_with_options")
       ::Log.builder.bind(log.source, :none, backend)
       log.level.should eq(::Log::Severity::None)

--- a/src/dexter/log.cr
+++ b/src/dexter/log.cr
@@ -147,9 +147,7 @@ class Log
       original_level = log_class.level
       begin
         backend = Log::IOBackend.new(io)
-        {% if compare_versions(Crystal::VERSION, "0.36.0-0") >= 0 %}
-          backend.dispatcher = Log::Dispatcher.for(:sync)
-        {% end %}
+        backend.dispatcher = Log::Dispatcher.for(:sync)
         if formatter
           backend.formatter = formatter
         end


### PR DESCRIPTION
# Purpose

Locks Lucky to Crystal version 1.4.0 or later.
# Description

With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.
